### PR TITLE
trying to get overcharging through debt account to work

### DIFF
--- a/all.go
+++ b/all.go
@@ -190,7 +190,7 @@ func (s *AllApiServiceImpl) SearchStudentBucks(ctx context.Context) (openapi.Imp
 
 		c := accounts.Cursor()
 		for k, _ := c.First(); k != nil; k, _ = c.Next() {
-			account, err := getStudentBaccountRoTx(tx, accounts.Bucket(k))
+			account, err := getStudentAccountRx(tx, accounts.Bucket(k))
 			if err != nil {
 				return err
 			}
@@ -200,6 +200,9 @@ func (s *AllApiServiceImpl) SearchStudentBucks(ctx context.Context) (openapi.Imp
 			if account.Id == CurrencyUBuck {
 				account.Buck.Name = "UBuck"
 				account.Conversion = 1
+			} else if account.Id == KeyDebt {
+				account.Buck.Name = "Debt"
+				account.Conversion = -1
 			} else {
 				conversion, err := xRateToBaseRx(tx, userDetails.SchoolId, account.Id, "")
 				if err != nil {
@@ -213,7 +216,7 @@ func (s *AllApiServiceImpl) SearchStudentBucks(ctx context.Context) (openapi.Imp
 				account.Buck.Name = owner.LastName + " Buck"
 			}
 
-			account, err = getCBaccountDetailsRoTx(tx, userDetails, account)
+			account, err = getCBaccountDetailsRx(tx, userDetails, account)
 			if err != nil {
 				return err
 			}

--- a/all_test.go
+++ b/all_test.go
@@ -284,7 +284,8 @@ func TestSearchStudentBucksNegative(t *testing.T) {
 	decoder := json.NewDecoder(resp.Body)
 	_ = decoder.Decode(&data)
 
-	assert.Equal(t, data[0].Balance, float32(1000))
+	assert.Equal(t, data[0].Balance, float32(1001))
+	assert.Equal(t, data[1].Balance, float32(1000))
 }
 
 func TestSearchStudentBucksUbuck(t *testing.T) {

--- a/allimpl.go
+++ b/allimpl.go
@@ -99,7 +99,7 @@ func getStudentHistoryTX(tx *bolt.Tx, userName string) (history []openapi.Histor
 	return
 }
 
-func getStudentBaccountRoTx(tx *bolt.Tx, bAccount *bolt.Bucket) (resp openapi.ResponseAccount, err error) {
+func getStudentAccountRx(tx *bolt.Tx, bAccount *bolt.Bucket) (resp openapi.ResponseAccount, err error) {
 	// historyData := bAccount.Get([]byte(KeyHistory))
 	// if historyData == nil {
 	// 	return resp, fmt.Errorf("Failed to get history")
@@ -115,7 +115,7 @@ func getStudentBaccountRoTx(tx *bolt.Tx, bAccount *bolt.Bucket) (resp openapi.Re
 	return
 }
 
-func getCBaccountDetailsRoTx(tx *bolt.Tx, userDetails UserInfo, account openapi.ResponseAccount) (finalAccount openapi.ResponseAccount, err error) {
+func getCBaccountDetailsRx(tx *bolt.Tx, userDetails UserInfo, account openapi.ResponseAccount) (finalAccount openapi.ResponseAccount, err error) {
 	cb, err := getCbRx(tx, userDetails.SchoolId)
 	if err != nil {
 		return

--- a/currencies.go
+++ b/currencies.go
@@ -279,13 +279,15 @@ func getCurrencyAccMMARx(account *bolt.Bucket) (decimal.Decimal, error) {
 	return d, nil
 }
 
-func convertRx(tx *bolt.Tx, schoolId, from, to string, amount float64) (float64, error) {
-	rate, err := xRateToBaseRx(tx, schoolId, from, to)
+func convertRx(tx *bolt.Tx, schoolId, from, to string, amount float64) (converted decimal.Decimal, xRate decimal.Decimal, err error) {
+	xRate, err = xRateToBaseRx(tx, schoolId, from, to)
 	if err != nil {
-		return rate.InexactFloat64(), err
+		return converted, xRate, err
 	}
 
-	return rate.InexactFloat64() * amount, nil
+	converted = xRate.Mul(decimal.NewFromFloat(amount))
+
+	return converted, xRate, nil
 
 }
 

--- a/go/model_response_account.go
+++ b/go/model_response_account.go
@@ -11,14 +11,13 @@
 package openapi
 
 type ResponseAccount struct {
-
 	Conversion float32 `json:"conversion,omitempty"`
 
 	History []History `json:"history,omitempty"`
 
 	Buck ResponseAccountBuck `json:"buck,omitempty"`
 
-	Balance float32 `json:"balance,omitempty"`
+	Balance float32 `json:"balance"`
 
 	Id string `json:"_id,omitempty"`
 

--- a/go/model_response_buck_transactions.go
+++ b/go/model_response_buck_transactions.go
@@ -15,7 +15,7 @@ import "time"
 type ResponseBuckTransaction struct {
 	CreatedAt time.Time `json:"createdAt,omitempty"`
 
-	Balance float32 `json:"balance,omitempty"`
+	Balance float32 `json:"balance"`
 
 	Description string `json:"description,omitempty"`
 

--- a/main.go
+++ b/main.go
@@ -195,6 +195,11 @@ func InitDefaultAccounts(db *bolt.DB) {
 		return
 	}
 
+	// err = seedDb(db, schoolId)
+	// if err != nil {
+	// 	lgr.Printf("ERROR seed items were not created: %v", err)
+	// 	return
+	// }
 }
 
 func initAuth(db *bolt.DB, config ServerConfig) *auth.Service {
@@ -277,4 +282,82 @@ func loadConfig() ServerConfig {
 	}
 
 	return config
+}
+
+func seedDb(db *bolt.DB, schoolId string) (err error) {
+	newUser := UserInfo{
+		Name:        "tt@tt.com",
+		FirstName:   "tt",
+		LastName:    "tt",
+		Email:       "tt@tt.com",
+		Confirmed:   true,
+		PasswordSha: EncodePassword("123qwe"),
+		SchoolId:    schoolId,
+		Role:        UserRoleTeacher,
+	}
+
+	err = createTeacher(db, newUser)
+	if err != nil {
+		return err
+	}
+
+	newUser.LastName = "tt2"
+	newUser.Name = "tt2@tt.com"
+	newUser.Email = "tt2@tt.com"
+
+	err = createTeacher(db, newUser)
+	if err != nil {
+		return err
+	}
+
+	newUser.LastName = "tt3"
+	newUser.Name = "tt3@tt.com"
+	newUser.Email = "tt3@tt.com"
+
+	err = createTeacher(db, newUser)
+	if err != nil {
+		return err
+	}
+
+	classId, _, err := CreateClass(db, schoolId, "tt@tt.com", "math", 1)
+	if err != nil {
+		return
+	}
+
+	path := PathId{
+		schoolId:  schoolId,
+		classId:   classId,
+		teacherId: "tt@tt.com",
+	}
+
+	newUser.Role = UserRoleStudent
+	newUser.LastName = "ss"
+	newUser.Name = "ss@ss.com"
+	newUser.Email = "ss@ss.com"
+
+	err = createStudent(db, newUser, path)
+	if err != nil {
+		return err
+	}
+
+	newUser.LastName = "ss1"
+	newUser.Name = "ss1@ss.com"
+	newUser.Email = "ss1@ss.com"
+
+	err = createStudent(db, newUser, path)
+	if err != nil {
+		return err
+	}
+
+	newUser.LastName = "ss2"
+	newUser.Name = "ss2@ss.com"
+	newUser.Email = "ss2@ss.com"
+
+	err = createStudent(db, newUser, path)
+	if err != nil {
+		return err
+	}
+
+	return
+
 }

--- a/schooladminimpl.go
+++ b/schooladminimpl.go
@@ -64,7 +64,7 @@ func CreateSchoolAdmin(db *bolt.DB, body UserInfo) (openapi.ImplResponse, error)
 			return err
 		}
 
-		schools, err := tx.CreateBucketIfNotExists([]byte("schools"))
+		schools, err := tx.CreateBucketIfNotExists([]byte(KeySchools))
 		if err != nil {
 			return err
 		}
@@ -75,7 +75,12 @@ func CreateSchoolAdmin(db *bolt.DB, body UserInfo) (openapi.ImplResponse, error)
 			return fmt.Errorf("school is not created")
 		}
 
-		admins, err := school.CreateBucketIfNotExists([]byte("admins"))
+		admins, err := school.CreateBucketIfNotExists([]byte(KeyAdmins))
+		if err != nil {
+			return err
+		}
+
+		_, err = school.CreateBucketIfNotExists([]byte(KeyStudents))
 		if err != nil {
 			return err
 		}

--- a/student_test.go
+++ b/student_test.go
@@ -428,6 +428,6 @@ func TestSearchBuckTransactionNegative(t *testing.T) {
 	decoder := json.NewDecoder(resp.Body)
 	err = decoder.Decode(&v)
 	require.Nil(t, err)
-	require.Equal(t, float32(-5000), v[0].Amount)
+	require.Equal(t, float32(50000), v[0].Amount)
 
 }

--- a/student_test.go
+++ b/student_test.go
@@ -395,3 +395,39 @@ func TestSearchBuckTransaction(t *testing.T) {
 	require.Equal(t, float32(-5000), v[0].Amount)
 
 }
+
+func TestSearchBuckTransactionNegative(t *testing.T) {
+	clock := AppClock{}
+	db, tearDown := FullStartTestServer("searchBuckTransactionNegative", 8090, "test@admin.com")
+	defer tearDown()
+	_, _, teachers, _, students, err := CreateTestAccounts(db, 1, 4, 2, 2)
+	require.Nil(t, err)
+
+	SetTestLoginUser(students[0])
+
+	// initialize http client
+	client := &http.Client{}
+
+	userDetails, err := getUserInLocalStore(db, students[0])
+	require.Nil(t, err)
+	for _, teach := range teachers {
+		err = pay2Student(db, &clock, userDetails, decimal.NewFromFloat(10000), teach, "pre load")
+		require.Nil(t, err)
+		err = chargeStudent(db, &clock, userDetails, decimal.NewFromFloat(50000), teach, "charge")
+		require.Nil(t, err)
+	}
+
+	req, _ := http.NewRequest(http.MethodGet, "http://127.0.0.1:8090/api/transactions/buckTransactions", nil)
+	resp, err := client.Do(req)
+	defer resp.Body.Close()
+	require.Nil(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, 200, resp.StatusCode, resp)
+
+	var v []openapi.ResponseBuckTransaction
+	decoder := json.NewDecoder(resp.Body)
+	err = decoder.Decode(&v)
+	require.Nil(t, err)
+	require.Equal(t, float32(-5000), v[0].Amount)
+
+}

--- a/studentimpl.go
+++ b/studentimpl.go
@@ -193,12 +193,12 @@ func StudentNetWorthTx(tx *bolt.Tx, userName string) (res decimal.Decimal) {
 			return decimal.Zero
 		}
 
-		ubuck, err := convertRx(tx, userData.SchoolId, string(k), "", value.InexactFloat64())
+		ubuck, _, err := convertRx(tx, userData.SchoolId, string(k), "", value.InexactFloat64())
 		if err != nil {
 			return
 		}
 
-		res = res.Add(decimal.NewFromFloat(ubuck))
+		res = res.Add(ubuck)
 
 	}
 
@@ -359,6 +359,71 @@ func pay2StudentTx(tx *bolt.Tx, clock Clock, userInfo UserInfo, amount decimal.D
 	return nil
 }
 
+func studentConvertTx(tx *bolt.Tx, clock Clock, userInfo UserInfo, amount decimal.Decimal, from string, to string) (err error) {
+	if userInfo.Role != UserRoleStudent {
+		return fmt.Errorf("user is not a student")
+	}
+	if amount.Sign() <= 0 {
+		return fmt.Errorf("amount must be positive")
+	}
+
+	ts := clock.Now().Truncate(time.Millisecond)
+
+	target := to
+	if to == KeyDebt {
+		target = ""
+	}
+	converted, xRate, err := convertRx(tx, userInfo.SchoolId, from, target, amount.InexactFloat64())
+	if err != nil {
+		return err
+	}
+
+	transaction := Transaction{
+		Ts:             ts,
+		Source:         userInfo.Name,
+		Destination:    userInfo.Name,
+		CurrencySource: from,
+		CurrencyDest:   to,
+		AmountSource:   amount,
+		AmountDest:     converted,
+		XRate:          xRate,
+		Reference:      "Convert",
+	}
+
+	student, err := getStudentBucketTx(tx, userInfo.Name)
+	if err != nil {
+		return err
+	}
+	if to != KeyDebt {
+		_, err = addToHolderTx(student, from, transaction, OperationDebit, true)
+		if err != nil {
+			return err
+		}
+	}
+
+	_, err = addToHolderTx(student, to, transaction, OperationCredit, true)
+	if err != nil {
+		return err
+	}
+
+	cb, err := getCbTx(tx, userInfo.SchoolId)
+	if err != nil {
+		return err
+	}
+
+	_, err = addToHolderTx(cb, from, transaction, OperationDebit, false)
+	if err != nil {
+		return err
+	}
+
+	_, err = addToHolderTx(cb, to, transaction, OperationDebit, false)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func chargeStudent(db *bolt.DB, clock Clock, userDetails UserInfo, amount decimal.Decimal, currency string, reference string) (err error) {
 	return db.Update(func(tx *bolt.Tx) error {
 		return chargeStudentTx(tx, clock, userDetails, amount, currency, reference)
@@ -397,7 +462,7 @@ func chargeStudentTx(tx *bolt.Tx, clock Clock, userDetails UserInfo, amount deci
 	}
 
 	if newBalance.Sign() < 0 {
-		err := pay2StudentTx(tx, clock, userDetails, amount, KeyDebt, reference)
+		err := studentConvertTx(tx, clock, userDetails, amount, currency, KeyDebt)
 		if err != nil {
 			return err
 		}

--- a/studentimpl_test.go
+++ b/studentimpl_test.go
@@ -37,9 +37,12 @@ func Test_ubuckFlow(t *testing.T) {
 	balance = StudentNetWorth(db, students[0])
 	require.Equal(t, .47, balance.InexactFloat64())
 
-	err = chargeStudent(db, &clock, userInfo, decimal.NewFromFloat(0.01), teachers[1], "some reason")
+	err = pay2Student(db, &clock, userInfo, decimal.NewFromFloat(0.01), teachers[1], "some reason")
+	require.Nil(t, err)
+
+	err = chargeStudent(db, &clock, userInfo, decimal.NewFromFloat(1), teachers[1], "some reason")
 	require.Nil(t, err)
 	balance = StudentNetWorth(db, students[0])
-	require.Equal(t, .46, balance.InexactFloat64())
+	require.Equal(t, -24.01999984, balance.InexactFloat64())
 
 }


### PR DESCRIPTION
this branch is failing at test TestSearchStudentBucksNegative, TestSearchBuckTransactionNegative

The scenario I am trying to code is this.
a teachers first transaction is to charge a student: error no xrate history. (unlikely event but it throws)

More likely is this:
teacher pays a student 10 tbucks
teacher charges same student 20 tbucks
since student account will be negative I want to redirect this event
I want to do nothing to students tbuck account
calculate or convert 20 tbuck to ?? ubuck lets says that this would be 25 ubucks
add 25 to a debt account
accounts should now be
tbucks: 10
debt: 25
ubuck: unchanged

I want teacher to see that the transaction occurred as a loss(negative) and reference is converted, regardless of what the teacher note was

student accounts should now list the debt account when calling searchStudentBucks
students transactions should now list the convert transaction into the dept account and it should be positive
cb/debt account should have recorded this transaction 