### PR TITLE
Crypto overuse

### DIFF
--- a/all.go
+++ b/all.go
@@ -310,7 +310,7 @@ func (a *AllApiServiceImpl) SearchStudent(ctx context.Context, Id string) (opena
 		nWorth := 0.0
 		job := openapi.UserNoHistoryJob{}
 		if searchedUser.Role == UserRoleStudent {
-			nWorth, _ = StudentNetWorthTx(tx, searchedUser.Email).Float64()
+			nWorth, _ = StudentNetWorthTx(tx, a.db, searchedUser.Email).Float64()
 			if searchedUser.College && searchedUser.CollegeEnd.IsZero() {
 				job = getJobRx(tx, KeyCollegeJobs, searchedUser.Job)
 			} else {
@@ -512,7 +512,7 @@ func (a *AllApiServiceImpl) SearchStudents(ctx context.Context) (openapi.ImplRes
 	var resp []openapi.UserNoHistory
 	var ranked int
 	err = a.db.Update(func(tx *bolt.Tx) error {
-		resp, ranked, err = getSchoolStudentsTx(tx, userDetails)
+		resp, ranked, err = getSchoolStudentsTx(tx, a.db, userDetails)
 		if err != nil {
 			return err
 		}

--- a/allimpl.go
+++ b/allimpl.go
@@ -254,7 +254,7 @@ func saveRanks(db *bolt.DB, students []openapi.UserNoHistory) (ranked int, err e
 	return
 }
 
-func getSchoolStudentsTx(tx *bolt.Tx, userDetails UserInfo) (resp []openapi.UserNoHistory, ranked int, err error) {
+func getSchoolStudentsTx(tx *bolt.Tx, db *bolt.DB, userDetails UserInfo) (resp []openapi.UserNoHistory, ranked int, err error) {
 	school, err := SchoolByIdTx(tx, userDetails.SchoolId)
 	if err != nil {
 		return
@@ -282,7 +282,7 @@ func getSchoolStudentsTx(tx *bolt.Tx, userDetails UserInfo) (resp []openapi.User
 			continue
 		}
 
-		nWorth, _ := StudentNetWorthTx(tx, student.Name).Float64()
+		nWorth, _ := StudentNetWorthTx(tx, db, student.Name).Float64()
 		nUser := openapi.UserNoHistory{
 			Id:        student.Email,
 			FirstName: student.FirstName,

--- a/student.go
+++ b/student.go
@@ -214,7 +214,7 @@ func (a *StudentApiServiceImpl) SearchCrypto(ctx context.Context, crypto string)
 	}
 
 	var resp openapi.ResponseCrypto
-	resp, err = getCrypto(a.db, userDetails, crypto)
+	resp, err = getCryptoForStudentRequest(a.db, userDetails, crypto)
 
 	if err != nil {
 		lgr.Printf("ERROR cannot get Cryptos for: %s %v", userDetails.Name, err)

--- a/student.go
+++ b/student.go
@@ -264,7 +264,7 @@ func (a *StudentApiServiceImpl) SearchStudentCrypto(ctx context.Context) (openap
 
 	var resp []CryptoDecimal
 	err = a.db.View(func(tx *bolt.Tx) error {
-		resp, err = getStudentCryptosRx(tx, userDetails)
+		resp, err = getStudentCryptosRx(tx, a.db, userDetails)
 		if err != nil {
 			return err
 		}

--- a/student_test.go
+++ b/student_test.go
@@ -45,7 +45,7 @@ func Test_addUbuck2Student(t *testing.T) {
 
 		_ = balance.UnmarshalText(v)
 
-		studentNetWo = StudentNetWorthTx(tx, students[0])
+		studentNetWo = StudentNetWorthTx(tx, db, students[0])
 		return nil
 	})
 

--- a/studentimpl_test.go
+++ b/studentimpl_test.go
@@ -109,7 +109,7 @@ func TestEvents(t *testing.T) {
 
 	netWorth := decimal.Zero
 	_ = db.View(func(tx *bolt.Tx) error {
-		netWorth = StudentNetWorthTx(tx, students[0])
+		netWorth = StudentNetWorthTx(tx, db, students[0])
 		return nil
 	})
 
@@ -252,7 +252,7 @@ func TestDailyPayment(t *testing.T) {
 
 	netWorth := decimal.Zero
 	_ = db.View(func(tx *bolt.Tx) error {
-		netWorth = StudentNetWorthTx(tx, students[0])
+		netWorth = StudentNetWorthTx(tx, db, students[0])
 		return nil
 	})
 

--- a/studentimpl_test.go
+++ b/studentimpl_test.go
@@ -385,12 +385,12 @@ func TestDebtInterest(t *testing.T) {
 	require.Greater(t, account.Balance, float32(2000))
 }
 
-func TestGetCrypto(t *testing.T) {
+func TestGetCryptoForStudentRequest(t *testing.T) {
 
-	lgr.Printf("INFO TestGetCrypto")
-	t.Log("INFO TestGetCrypto")
+	lgr.Printf("INFO TestGetCryptoForStudentRequest")
+	t.Log("INFO TestGetCryptoForStudentRequest")
 	clock := TestClock{}
-	db, dbTearDown := OpenTestDB("getCrypto")
+	db, dbTearDown := OpenTestDB("getCryptoForStudentRequest")
 	defer dbTearDown()
 	_, _, _, _, students, _ := CreateTestAccounts(db, 1, 1, 1, 1)
 
@@ -399,16 +399,16 @@ func TestGetCrypto(t *testing.T) {
 	err = pay2Student(db, &clock, student, decimal.NewFromFloat(10000), CurrencyUBuck, "pre load")
 	require.Nil(t, err)
 
-	resp, err := getCrypto(db, student, "bitCoin")
+	resp, err := getCryptoForStudentRequest(db, student, "bitCoin")
 	require.Nil(t, err)
 
-	resp2, err := getCrypto(db, student, "bitCoin")
+	resp2, err := getCryptoForStudentRequest(db, student, "bitCoin")
 	require.Nil(t, err)
 	require.Equal(t, resp.Usd, resp2.Usd)
 
 	clock.TickOne(time.Minute * 2)
 
-	resp, err = getCrypto(db, student, "bitCoin")
+	resp, err = getCryptoForStudentRequest(db, student, "bitCoin")
 
 	var bitcoin openapi.CryptoCb
 	err = db.View(func(tx *bolt.Tx) error {
@@ -444,13 +444,13 @@ func TestCryptoTransaction(t *testing.T) {
 		Sell: 0,
 	}
 
-	resp, err := getCrypto(db, student, "Cardano")
+	resp, err := getCryptoForStudentRequest(db, student, "Cardano")
 	require.Nil(t, err)
 	require.Equal(t, float32(0), resp.Owned)
 
 	err = cryptoTransaction(db, &clock, student, body)
 
-	resp, err = getCrypto(db, student, "Cardano")
+	resp, err = getCryptoForStudentRequest(db, student, "Cardano")
 	require.Nil(t, err)
 	require.Equal(t, float32(10), resp.Owned)
 
@@ -470,13 +470,13 @@ func TestCryptoTransaction(t *testing.T) {
 
 	err = cryptoTransaction(db, &clock, student, body)
 	require.Nil(t, err)
-	resp, err = getCrypto(db, student, "Cardano")
+	resp, err = getCryptoForStudentRequest(db, student, "Cardano")
 	require.Nil(t, err)
 	require.Equal(t, float32(5), resp.Owned)
 
 	err = cryptoTransaction(db, &clock, student, body)
 	require.Nil(t, err)
-	resp, err = getCrypto(db, student, "Cardano")
+	resp, err = getCryptoForStudentRequest(db, student, "Cardano")
 	require.Nil(t, err)
 	require.Equal(t, float32(0), resp.Owned)
 


### PR DESCRIPTION
getCryptoLatest hits an api which I am has limits. I am easily hitting those limits. My original intention was to only hit the api when a cryptos data is greater than 1 min old. This is why we created getCrypto. getCrypto determines when to use a view and update of db, calls getCryptoLatest and then saves the results. The problem is I used getCryptoLatest in multiple locations. So it calls the api and does not check or save the latest data. This causes us to got over our limit. I want to only run getCryptoLatest in getCrypto  as it works as a good manager. I am having difficulty because some of the methods that call it are already RX or TX so getCrypto cannot choose the right action. I am having problems finding a solution. The latest commit does not work but I hope you can see my logic. The second to last does work.